### PR TITLE
Adding Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@
 
 # Mac junk
 **/.DS_Store
+
+# Build folder
+*.bin
+*.zip
+*.err

--- a/86c764x.md5
+++ b/86c764x.md5
@@ -1,0 +1,1 @@
+fbc57ef320053c50d9034ef493abda4d  86c764x.bin

--- a/makefile
+++ b/makefile
@@ -1,0 +1,25 @@
+# Makefile for Assembly x86 project
+
+# Default target
+all: build
+
+# Clean build artifacts
+clean:
+	rm -f 86c764x.bin
+	rm -f 86c764x.err
+	rm -f 86c764x.zip
+
+# Build the project
+build: 86c764x.bin
+
+86c764x.bin: research/s3/bios/86c764x.asm
+	jwasm -Fw86c764x.err -Fo86c764x.bin -bin research/s3/bios/86c764x.asm;
+
+# Run tests
+test:
+	md5sum -c 86c764x.md5
+
+# Package the project
+package:
+    # Add packaging commands here
+	zip -9 86c764x.zip 86c764x.bin 86c764x.md5


### PR DESCRIPTION
Adding a makefile that will build `86c764x.asm` using jwasm. There are a few targets.
- 'make build'
- 'make clean' clean all the built files
- 'make test': test the md5sum of 86c764x.asm with a known good value.
- 'make package': build a 86c764x.zip file of the binary

'make test' will compare the `md5sum` of the output with the known good md5sum.